### PR TITLE
Improve training logging and checkpointing

### DIFF
--- a/scripts/make_tfrecords.py
+++ b/scripts/make_tfrecords.py
@@ -25,13 +25,13 @@ def main():
     args = parse_args()
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
-    print("Writing train TFRecords...")
+    print("Writing train TFRecords...", flush=True)
     write_tfrecords_from_yaml(args.data, str(out), split='train', shards=args.shards,
                               update_every=args.update_every, num_workers=args.workers, use_processes=args.mp)
-    print("Writing val TFRecords...")
+    print("Writing val TFRecords...", flush=True)
     write_tfrecords_from_yaml(args.data, str(out), split='val', shards=max(1, args.shards // 2),
                               update_every=args.update_every, num_workers=args.workers, use_processes=args.mp)
-    print(f"Done. TFRecords stored under {out}")
+    print(f"Done. TFRecords stored under {out}", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log command-line arguments, dataset stats and output locations at the start of training and clarify resume decisions
- add reusable validation loss computation, report validation loss alongside metrics and only save checkpoints when it improves (tracking best loss on disk)
- ensure TFRecord creation prints progress immediately so the script no longer appears stalled

## Testing
- python -m compileall train.py scripts/make_tfrecords.py yolo11_tf

------
https://chatgpt.com/codex/tasks/task_e_68ca24d97e18832692d3fdd863f78799