### PR TITLE
Fix task align metric broadcasting

### DIFF
--- a/yolo11_tf/train_utils.py
+++ b/yolo11_tf/train_utils.py
@@ -110,8 +110,8 @@ class TaskAlignedAssignerTF:
             norm_align_metric = tf.reduce_max(
                 align_metric * pos_overlaps / (pos_align_metrics + self.eps),
                 axis=-2,
-                keepdims=True,
             )
+            norm_align_metric = tf.expand_dims(norm_align_metric, axis=-1)
             target_scores = target_scores * norm_align_metric
             return target_labels, target_bboxes, target_scores, tf.cast(fg_mask > 0, tf.bool), target_gt_idx
 


### PR DESCRIPTION
## Summary
- reshape the normalized alignment metric in TaskAlignedAssignerTF so it matches target score dimensions
- avoid INVALID_ARGUMENT broadcast errors during training when multiplying by target scores

## Testing
- python -m compileall yolo11_tf/train_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d85e7488e88326a68169ffe710d80d