### PR TITLE
Align TensorFlow training loop with Ultralytics YOLO11 scheduling

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,8 +130,15 @@ def main():
     prefer_gpu_ops = not bool(getattr(args, 'safe_cpu', False))
     with strategy.scope():
         model = build_yolo11(num_classes=num_classes, width_mult=width_mult, depth_mult=depth_mult)
-        cfg = TrainConfig(num_classes=num_classes, img_size=args.imgsz, reg_max=16, lr=args.lr,
-                          prefer_gpu_ops=prefer_gpu_ops, debug_asserts=bool(args.debug_asserts))
+        cfg = TrainConfig(
+            num_classes=num_classes,
+            img_size=args.imgsz,
+            reg_max=16,
+            lr0=args.lr,
+            batch_size=args.batch,
+            prefer_gpu_ops=prefer_gpu_ops,
+            debug_asserts=bool(args.debug_asserts),
+        )
         trainer = Trainer(model, cfg, strategy=strategy)
 
     train_iterable = trainer.distribute_dataset(train_ds)

--- a/yolo11_tf/cfg/default.yaml
+++ b/yolo11_tf/cfg/default.yaml
@@ -3,9 +3,16 @@ train:
   imgsz: 640
   batch: 16
   epochs: 100
-  lr0: 0.001
+  lr0: 0.01
+  lrf: 0.01
+  momentum: 0.937
   warmup_epochs: 3.0
+  warmup_momentum: 0.8
+  warmup_bias_lr: 0.1
   weight_decay: 0.0005
+  optimizer: SGD
+  nbs: 64
+  cos_lr: false
 loss:
   box: 7.5
   cls: 0.5

--- a/yolo11_tf/config.py
+++ b/yolo11_tf/config.py
@@ -18,9 +18,16 @@ class TrainSettings:
     imgsz: int = 640
     batch: int = 16
     epochs: int = 100
-    lr0: float = 1e-3
+    lr0: float = 0.01
+    lrf: float = 0.01
+    momentum: float = 0.937
     warmup_epochs: float = 3.0
+    warmup_momentum: float = 0.8
+    warmup_bias_lr: float = 0.1
     weight_decay: float = 5e-4
+    optimizer: str = "SGD"
+    nbs: int = 64
+    cos_lr: bool = False
 
     @classmethod
     def from_dict(cls, data: Optional[Dict[str, Any]] = None) -> "TrainSettings":


### PR DESCRIPTION
## Summary
- add Ultralytics-style optimizer, scheduler, and warmup parameters to the shared training configuration and trainer utilities
- update the TensorFlow training loop to follow YOLO11 learning-rate/momentum scheduling and validation thresholds while improving logging
- refresh the default training YAML to match the latest Ultralytics hyper-parameter defaults

## Testing
- python -m compileall train_ultra.py yolo11_tf/train_utils.py yolo11_tf/config.py
- python -m compileall train.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e86f67448326b18f64b79f4409e6